### PR TITLE
Update Slovenia.php

### DIFF
--- a/Date/Holidays/Driver/Slovenia.php
+++ b/Date/Holidays/Driver/Slovenia.php
@@ -72,6 +72,9 @@ class Date_Holidays_Driver_Slovenia extends Date_Holidays_Driver
          * New Year's Day
          */
         $this->_addHoliday('novoleto1', $this->_year . '-01-01', 'Novo leto');
+        if ($this->_year < 2013) {
+            $this->_addHoliday('novoleto2', $this->_year . '-01-02', 'Novo leto');
+        }
 
         /**
          * Prešernov dan

--- a/Date/Holidays/Driver/Slovenia.php
+++ b/Date/Holidays/Driver/Slovenia.php
@@ -72,7 +72,6 @@ class Date_Holidays_Driver_Slovenia extends Date_Holidays_Driver
          * New Year's Day
          */
         $this->_addHoliday('novoleto1', $this->_year . '-01-01', 'Novo leto');
-        $this->_addHoliday('novoleto2', $this->_year . '-01-02', 'Novo leto');
 
         /**
          * Prešernov dan


### PR DESCRIPTION
1. january is no longer a public holiday.
   Since 6. 6. 2013; ZUJF-NPB3 http://www.mddsz.gov.si/fileadmin/mddsz.gov.si/pageuploads/dokumenti__pdf/zakonodaja/ZUJF-NPB3.pdf
