### PR TITLE
Fix substitute holidays from 2007-01-01.

### DIFF
--- a/Date/Holidays/Driver/Japan.php
+++ b/Date/Holidays/Driver/Japan.php
@@ -618,14 +618,15 @@ class Date_Holidays_Driver_Japan extends Date_Holidays_Driver
     function _buildSubstituteHolidays()
     {
         // calculate 'current' substitute holidays
-        foreach ($this->_dates as $internalName => $date) {
+        foreach ($this->_dates as $internalName => $_date) {
+            $date = clone $_date;
             if ($date->format('w') == 0) {
                 if ($this->_year >= 2007) {
                     while (in_array($date, $this->_dates)) {
-                        $date = $date->add( new DateInterval('P1D'));
+                        $date->add(new DateInterval('P1D'));
                     }
                 } else if ($date->getDate() >= '1973-04-12') {
-                    $date = $date->add( new DateInterval('P1D'));
+                    $date->add(new DateInterval('P1D'));
                     if (in_array($date, $this->_dates)) {
                         continue;
                     }


### PR DESCRIPTION
`$date->add(new DateInterval('P1D'));`  change object it self. So must clone object.

http://php.net/manual/en/datetime.add.php

ex 
```
2017-01
S_ M_ T_ W_ T_ F_ S_
01 02 03 04 05 06 07
08 ...
```

01 -> Sunday & New Year's Day
02 -> Substitute Holiday for New Year's Day